### PR TITLE
Improve CI trigger and concurrency

### DIFF
--- a/.github/workflows/cmake-lint.yml
+++ b/.github/workflows/cmake-lint.yml
@@ -1,6 +1,14 @@
 name: "CMake Lint"
 
 on:
+  # always run on main branch
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+  # run on PR to main branch if relevant files changed
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/cpp-build.yml
+++ b/.github/workflows/cpp-build.yml
@@ -1,6 +1,14 @@
 name: "C++ Build"
 
 on:
+  # always run on main branch
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+  # run on PR to main branch if relevant files changed
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -1,6 +1,14 @@
 name: "C++ Lint"
 
 on:
+  # always run on main branch
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+  # run on PR to main branch if relevant files changed
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/cpp-unittest.yml
+++ b/.github/workflows/cpp-unittest.yml
@@ -1,6 +1,14 @@
 name: "C++ Unittests"
 
 on:
+  # always run on main branch
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+  # run on PR to main branch if relevant files changed
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,14 @@
 name: "C++/CMake Format"
 
 on:
+  # always run on main branch
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+  # run on PR to main branch if relevant files changed
   pull_request:
     branches: [ main ]
     paths:


### PR DESCRIPTION
Outdated CI jobs will now be cancelled and a workflow is only run if relevant files were changed.
Additionally, the CI only runs on pull requests to the main branch.

This is done to reduce the number of CI jobs and save computation resources.