### PR TITLE
Minor README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PPPlugin
 
-[!WARNING]
-Until version 1.0.0 is released, all interfaces and features are subject
-to change and there are no guarantees regarding stability.
+> [!WARNING]
+> Until version 1.0.0 is released, all interfaces and features are subject
+> to change and there are no guarantees regarding stability.
 
 This library aims to provide an easy-to-use and modern C++ interface
 to extend an existing library at runtime via plugins.
@@ -17,7 +17,7 @@ interchangeably.
 # set(PPPLUGIN_SHARED ON) # uncomment to use shared instead of static library
 find_package(ppplugin REQUIRED)
 
-target_link_library(<target> ppplugin::ppplugin)
+target_link_library(<target> PRIVATE ppplugin::ppplugin)
 ```
 
 For code usage, please refer to the different examples in `examples/`.
@@ -32,7 +32,8 @@ cmake --build build -j
 cmake --install build --prefix build/root/usr/local
 ```
 
-This will compile and install the library to the directory `build/root`.
+This will compile and install the library to the directories
+`build/root/usr/local/{include,lib}`.
 
 Available compilation options:
 
@@ -42,8 +43,8 @@ Available compilation options:
 | `PPPLUGIN_ENABLE_COVERAGE` | `OFF` | Enable flags for measuring test coverage |
 | `PPPLUGIN_ENABLE_TESTS`    | `OFF` | Tests in `tests` will be compiled        |
 | `PPPLUGIN_ENABLE_EXAMPLES` | `OFF` | Examples in `examples` will be compiled  |
-| `DPPPLUGIN_ENABLE_CPP17_COMPATIBILITY` | `OFF` |                              |
-||| Library will be compiled with C++17 compatibility                           |
+| `PPPLUGIN_ENABLE_CPP17_COMPATIBILITY` | `OFF` | Library will be compiled   \\ |
+||| with C++17 compatibility                                                    |
 
 Extend the first command above with the desired options, for example:
 


### PR DESCRIPTION
This PR fixes the formatting for the warning box for pre-1.0 stability and the cmake option table.
The ugly wrap-around is unfortunately necessary to satisfy markdown linters which require a column limit of 80, but tables do not allow line splitting.

Additionally, a small clarification for the installation path for the cmake example command and the PRIVATE keyword was added to the example for cmake integration.