### PR TITLE
Fix PythonException for Python 3.12

### DIFF
--- a/src/python_exception.cpp
+++ b/src/python_exception.cpp
@@ -23,7 +23,7 @@ std::optional<PythonException> PythonException::latest()
     PythonObject exception { PyErr_GetRaisedException() };
     PythonObject type { PyObject_Type(exception.pyObject()) };
     PythonObject args_tuple { PyException_GetArgs(exception.pyObject()) };
-    PythonObject value { (PyTuple_Size(args_tuple.pyObject()) > 0) ? args_tuple
+    PythonObject value { (PyTuple_Size(args_tuple.pyObject()) > 0) ? PyTuple_GetItem(args_tuple.pyObject(), 0)
                                                                    : nullptr };
     PythonObject traceback { PyException_GetTraceback(exception.pyObject()) };
 #else


### PR DESCRIPTION
Python 3.12 introduced a different method for exception retrieval. The explicit size check in `ppplugin` for the tuple is so that no IndexError exception is set by Python.