### PR TITLE
Add multi-language generic tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(${TESTS_NAME} PRIVATE GTest::GTest GTest::Main gmock
 add_subdirectory(lua_tests)
 add_subdirectory(shell_tests)
 add_subdirectory(python_tests)
+add_subdirectory(generic_plugin_tests)
 
 gtest_discover_tests(${TESTS_NAME})
 

--- a/test/generic_plugin_tests/CMakeLists.txt
+++ b/test/generic_plugin_tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+target_sources(${TESTS_NAME} PRIVATE generic_plugin_tests.cpp)
+
+add_custom_target(generic_plugin_tests ALL COMMENT "GenericPlugin test files")
+add_custom_command(
+  TARGET generic_plugin_tests
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/test.py
+          ${CMAKE_CURRENT_BINARY_DIR}/test.py
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/test.lua
+          ${CMAKE_CURRENT_BINARY_DIR}/test.lua
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/test.sh
+          ${CMAKE_CURRENT_BINARY_DIR}/test.sh
+  COMMENT "Copying generic test plugins to output directory...")

--- a/test/generic_plugin_tests/generic_plugin_tests.cpp
+++ b/test/generic_plugin_tests/generic_plugin_tests.cpp
@@ -1,0 +1,53 @@
+#include "test_helper.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <ppplugin/plugin.h>
+
+template <typename T, const char* path>
+struct TestParameter {
+    using PluginType = T;
+    static constexpr auto PLUGIN_PATH = path;
+};
+
+template <typename T>
+class GenericPluginTests : public testing::TestWithParam<T> {
+public:
+    void SetUp() override
+    {
+    }
+
+    /**
+     * Load plugin and return it on success.
+     * On failure, an EXPECT statement will fail and a NoopPlugin is returned.
+     */
+    template <typename P>
+    static ppplugin::Plugin load(const std::filesystem::path& plugin_path)
+    {
+        return P::load(plugin_path)
+            .andThen([](auto&& plugin) { return ppplugin::Plugin { std::forward<decltype(plugin)>(plugin) }; })
+            .valueOrElse([](auto&& error) -> ppplugin::Plugin {
+                EXPECT_TRUE(false) << error;
+                return ppplugin::NoopPlugin {};
+            });
+    }
+};
+TYPED_TEST_SUITE_P(GenericPluginTests);
+
+const char python_plugin_path[] = "./generic_plugin_tests/test.py";
+const char lua_plugin_path[] = "./generic_plugin_tests/test.lua";
+const char shell_plugin_path[] = "./generic_plugin_tests/test.sh";
+
+using Types = testing::Types<
+    TestParameter<ppplugin::PythonPlugin, python_plugin_path>,
+    TestParameter<ppplugin::LuaPlugin, lua_plugin_path>,
+    TestParameter<ppplugin::ShellPlugin, shell_plugin_path>>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(GenericPluginTest, GenericPluginTests, Types);
+
+TYPED_TEST_P(GenericPluginTests, loadingSuccess)
+{
+    auto plugin = decltype(*this)::template load<TypeParam>("./generic_plugin_tests/test.py");
+    EXPECT_TRUE(static_cast<bool>(plugin));
+}

--- a/test/generic_plugin_tests/test.lua
+++ b/test/generic_plugin_tests/test.lua
@@ -1,0 +1,38 @@
+string_global = "abc"
+int_global = 12
+float_global = 42.0
+bool_global = false
+char_global = "9"
+dict_global = { a = {}, b = { f = false }, c = { t = true } }
+list_global = { {}, { 0 }, { 0, false } }
+
+function get_global(name)
+    return _G[name]
+end
+
+function accept_int_string_bool_float(i, s, b, f)
+    local is_integer = type(i) == "number"
+    local is_float = type(f) == "number"
+    local is_string = type(s) == "string"
+    local is_bool = type(b) == "boolean"
+
+    return is_integer and is_float and is_string and is_bool
+end
+
+function accept_list(t)
+    local result = ""
+    table.sort(t)
+    for _, v in ipairs(t) do
+        result = result .. tostring(v) .. ","
+    end
+    return result
+end
+
+function accept_dict(t)
+    t["new"] = "new value"
+    return t
+end
+
+function identity(x)
+    return x
+end

--- a/test/generic_plugin_tests/test.py
+++ b/test/generic_plugin_tests/test.py
@@ -1,0 +1,36 @@
+string_global = "abc"
+int_global = 12
+float_global = 42.0
+bool_global = False
+char_global = "9"
+dict_global = {"a": {}, "b": {"f": False}, "c": {"t": True}}
+list_global = [[], [1], [2, 3]]
+
+
+def get_global(name):
+    return globals()[name]
+
+
+def accept_int_string_bool_float(i, s, b, f):
+    is_int = type(i) is int
+    is_string = type(s) is str
+    is_bool = type(b) is bool
+    is_float = type(f) is float
+
+    return is_int and is_string and is_bool and is_float
+
+
+def accept_dict(d):
+    d["new"] = "new value"
+    return d
+
+
+def accept_list(l):
+    result = ""
+    for e in l:
+        result += e + ","
+    return result
+
+
+def identity(x):
+    return x

--- a/test/generic_plugin_tests/test.sh
+++ b/test/generic_plugin_tests/test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+export string_global="abc"
+export int_global=12
+export float_global=42.0
+export bool_global=0
+export char_global="9"
+export list_global='"" "1" "1 2"'
+
+
+get_global(name) {
+    eval "echo ${name}"
+}
+
+
+accept_int_string_bool_float(i, s, b, f) {
+    if [ $# == 4 ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+
+accept_dict() {
+}
+
+
+accept_list() {
+    for x in ${1}; do
+        echo "${x},"
+    done
+}
+
+
+identity() {
+    echo "${1}"
+}


### PR DESCRIPTION
Currently, `GenericPlugin` is not tested at all.
Additionally, a lot of duplicate test code can be avoided by utilizing the uniform interface the plugins provide.

This PR introduces tests that can be executed for each plugin type and also tests for `GenericPlugin` to increase the test coverage.